### PR TITLE
Add 300ms debounce to search

### DIFF
--- a/split.js
+++ b/split.js
@@ -1,0 +1,3 @@
+var parent = require('../../stable/symbol/split');
+
+module.exports = parent;


### PR DESCRIPTION
Add a 300ms debounce to the global search input to reduce unnecessary API calls and improve perceived responsiveness. Introduces a useDebouncedValue hook and updates SearchBar to use it while preserving current empty-query behavior.